### PR TITLE
Support single image input for ImageBatchMultiple

### DIFF
--- a/image.py
+++ b/image.py
@@ -68,8 +68,7 @@ class ImageBatchMultiple:
     CATEGORY = "essentials/image batch"
 
     def execute(self, image_1, method, image_2=None, image_3=None, image_4=None, image_5=None):
-        if all(img is None for img in (image_2, image_3, image_4, image_5)):
-            return (image_1,)
+        out = image_1
 
         if image_2 is not None:
             if image_1.shape[1:] != image_2.shape[1:]:

--- a/image.py
+++ b/image.py
@@ -68,27 +68,27 @@ class ImageBatchMultiple:
     CATEGORY = "essentials/image batch"
 
     def execute(self, image_1, method, image_2=None, image_3=None, image_4=None, image_5=None):
-        images = [image_1]
+        if all(img is None for img in (image_2, image_3, image_4, image_5)):
+            return (image_1,)
 
         if image_2 is not None:
             if image_1.shape[1:] != image_2.shape[1:]:
                 image_2 = comfy.utils.common_upscale(image_2.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-            images.append(image_2)
+            out = torch.cat((image_1, image_2), dim=0)
         if image_3 is not None:
             if image_1.shape[1:] != image_3.shape[1:]:
                 image_3 = comfy.utils.common_upscale(image_3.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-            images.append(image_3)
+            out = torch.cat((out, image_3), dim=0)
         if image_4 is not None:
             if image_1.shape[1:] != image_4.shape[1:]:
                 image_4 = comfy.utils.common_upscale(image_4.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-            images.append(image_4)
+            out = torch.cat((out, image_4), dim=0)
         if image_5 is not None:
             if image_1.shape[1:] != image_5.shape[1:]:
                 image_5 = comfy.utils.common_upscale(image_5.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-            images.append(image_5)
+            out = torch.cat((out, image_5), dim=0)
 
-        out = torch.cat(images, dim=0)
-        return (out, )
+        return (out,)
 
 
 class ImageExpandBatch:

--- a/image.py
+++ b/image.py
@@ -55,9 +55,9 @@ class ImageBatchMultiple:
         return {
             "required": {
                 "image_1": ("IMAGE",),
-                "image_2": ("IMAGE",),
                 "method": (["nearest-exact", "bilinear", "area", "bicubic", "lanczos"], { "default": "lanczos" }),
             }, "optional": {
+                "image_2": ("IMAGE",),
                 "image_3": ("IMAGE",),
                 "image_4": ("IMAGE",),
                 "image_5": ("IMAGE",),
@@ -67,25 +67,28 @@ class ImageBatchMultiple:
     FUNCTION = "execute"
     CATEGORY = "essentials/image batch"
 
-    def execute(self, image_1, image_2, method, image_3=None, image_4=None, image_5=None):
-        if image_1.shape[1:] != image_2.shape[1:]:
-            image_2 = comfy.utils.common_upscale(image_2.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-        out = torch.cat((image_1, image_2), dim=0)
+    def execute(self, image_1, method, image_2=None, image_3=None, image_4=None, image_5=None):
+        images = [image_1]
 
+        if image_2 is not None:
+            if image_1.shape[1:] != image_2.shape[1:]:
+                image_2 = comfy.utils.common_upscale(image_2.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
+            images.append(image_2)
         if image_3 is not None:
             if image_1.shape[1:] != image_3.shape[1:]:
                 image_3 = comfy.utils.common_upscale(image_3.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-            out = torch.cat((out, image_3), dim=0)
+            images.append(image_3)
         if image_4 is not None:
             if image_1.shape[1:] != image_4.shape[1:]:
                 image_4 = comfy.utils.common_upscale(image_4.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-            out = torch.cat((out, image_4), dim=0)
+            images.append(image_4)
         if image_5 is not None:
             if image_1.shape[1:] != image_5.shape[1:]:
                 image_5 = comfy.utils.common_upscale(image_5.movedim(-1,1), image_1.shape[2], image_1.shape[1], method, "center").movedim(1,-1)
-            out = torch.cat((out, image_5), dim=0)
+            images.append(image_5)
 
-        return (out,)
+        out = torch.cat(images, dim=0)
+        return (out, )
 
 
 class ImageExpandBatch:


### PR DESCRIPTION
Hi cubiq,

I've made some modifications to `ImageBatchMultiple` to support input ranging from 1 to N images. 

Often, when testing workflows, the number of images might decrease from multiple to just one. Previously, if `ImageBatchMultiple` did not support a single image input, we would need to modify the workflow to replace `ImageBatchMultiple` with another node. 

With this update, if `ImageBatchMultiple` supports a single image input, we can test without needing to change the workflow.

Hope it helps!