### PR TITLE
Improve LUTs managements

### DIFF
--- a/image.py
+++ b/image.py
@@ -1523,7 +1523,7 @@ IMAGE_CLASS_MAPPINGS = {
     "ImageToDevice+": ImageToDevice,
     "ImagePreviewFromLatent+": ImagePreviewFromLatent,
     "NoiseFromImage+": NoiseFromImage,
-
+    "StringToLuts+": StringToLuts,
     #"ExtractKeyframes+": ExtractKeyframes,
 }
 
@@ -1566,4 +1566,5 @@ IMAGE_NAME_MAPPINGS = {
     "ImageToDevice+": "🔧 Image To Device",
     "ImagePreviewFromLatent+": "🔧 Image Preview From Latent",
     "NoiseFromImage+": "🔧 Noise From Image",
+    "StringToLuts+": "🔧 String To Luts",
 }

--- a/image.py
+++ b/image.py
@@ -972,12 +972,13 @@ class ImageApplyLUT:
 
     # TODO: check if we can do without numpy
     def execute(self, image, lut_file, gamma_correction, clip_values, strength):
-        from colour.io.luts.iridas_cube import read_LUT_IridasCube
-
         lut_file_path = folder_paths.get_full_path("luts", lut_file)
         if not lut_file_path or not Path(lut_file_path).exists():
-            raise FileNotFoundError(f"Could not find LUT file: {lut_file_path}")
-
+            print(f"Could not find LUT file: {lut_file_path}")
+            return (image,)
+            
+        from colour.io.luts.iridas_cube import read_LUT_IridasCube
+        
         device = image.device
         lut = read_LUT_IridasCube(lut_file_path)
         lut.name = lut_file


### PR DESCRIPTION
This PR:
- Switch to `./models` directory for LUTs while keeping compatibility with `./custom_nodes/ComfyUI_essentials/luts`.
- Make subdirectory luts usable and fix https://github.com/cubiq/ComfyUI_essentials/issues/45
- Introduce a `StringToLuts+` helper to still be able to parametrize LUTs