### PR TITLE
KSamplerVariationsWithNoise+: fix sigmas on the wrong device error

### DIFF
--- a/sampling.py
+++ b/sampling.py
@@ -89,7 +89,8 @@ class KSamplerVariationsWithNoise:
         sigmas = sampler.sigmas
         sigma = sigmas[start_at_step] - sigmas[end_at_step]
         sigma /= model.model.latent_format.scale_factor
-        sigma = sigma.detach().cpu().item()
+        # Ensure sigma is on the same device as other tensors
+        sigma = torch.tensor(sigma, device=slerp_noise.device)
 
         work_latent = latent_image.copy()
         work_latent["samples"] = latent_image["samples"].clone() + slerp_noise * sigma


### PR DESCRIPTION
I created and ran a workflow with KSamplerVariationsWithNoise+ and got the following error:
```
!!! Exception during processing!!! Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
 Traceback (most recent call last):
 File "/comfyui/execution.py", line 152, in recursive_execute
    output_data, output_ui = get_output_data(obj, input_data_all)
 File "/comfyui/execution.py", line 82, in get_output_data
    return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
File "/comfyui/execution.py", line 75, in map_node_over_list
     results.append(getattr(obj, func)(**slice_dict(input_data_all, i)))
  File "/comfyui/custom_nodes/ComfyUI_essentials/sampling.py", line 95, in execute
   work_latent["samples"] = latent_image["samples"].clone() + slerp_noise * sigma
 RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```
I updated the code put the copy sigmas onto same device as latent_image.