### PR TITLE
Make threshold 128 instead of 127 so that the threshold can cover the whole color range

### DIFF
--- a/mask.py
+++ b/mask.py
@@ -202,7 +202,7 @@ class MaskFromColor:
                 "red": ("INT", { "default": 255, "min": 0, "max": 255, "step": 1, }),
                 "green": ("INT", { "default": 255, "min": 0, "max": 255, "step": 1, }),
                 "blue": ("INT", { "default": 255, "min": 0, "max": 255, "step": 1, }),
-                "threshold": ("INT", { "default": 0, "min": 0, "max": 127, "step": 1, }),
+                "threshold": ("INT", { "default": 0, "min": 0, "max": 128, "step": 1, }),
             }
         }
 


### PR DESCRIPTION
I used this node as part of a workflow and found it would be really nice to have this one number change. If you use 127, values at 255 would be outside the threshold, and if you use 128, values at 0 would be outside the threshold.

127 + 127 = 254
128 - 127 = 1

So this makes it so you can set threshold to 128, which allows full coverage if you want that.