### PR TITLE
Add resolution multiplier to SDXLEmptyLatentSizePicker

### DIFF
--- a/misc.py
+++ b/misc.py
@@ -472,17 +472,21 @@ class SDXLEmptyLatentSizePicker:
             "batch_size": ("INT", {"default": 1, "min": 1, "max": 4096}),
             "width_override": ("INT", {"default": 0, "min": 0, "max": MAX_RESOLUTION, "step": 8}),
             "height_override": ("INT", {"default": 0, "min": 0, "max": MAX_RESOLUTION, "step": 8}),
+            "resolution_multiplier": ("FLOAT", {"default": 1, "min": 0, "max": 100, "step": 0.5}),
             }}
 
     RETURN_TYPES = ("LATENT","INT","INT",)
     RETURN_NAMES = ("LATENT","width","height",)
-    FUNCTION = "execute"
-    CATEGORY = "essentials/utilities"
+    FUNCTION     = "execute"
+    CATEGORY     = "essentials/utilities"
 
-    def execute(self, resolution, batch_size, width_override=0, height_override=0):
+    def execute(self, resolution, batch_size, width_override=0, height_override=0, resolution_multiplier=1.0):
         width, height = resolution.split(" ")[0].split("x")
-        width = width_override if width_override > 0 else int(width)
-        height = height_override if height_override > 0 else int(height)
+        width         = width_override  if width_override  > 0 else int(width)
+        height        = height_override if height_override > 0 else int(height)
+
+        width  = int(resolution_multiplier * width)
+        height = int(resolution_multiplier * height)
 
         latent = torch.zeros([batch_size, 4, height // 8, width // 8], device=self.device)
 


### PR DESCRIPTION
Currently, there are models such as Illustrious v1.0, and now v2.0 that were trained on resolutions higher than standard SDXL sizes, around 1.5x-2.0x SDXL resolutions. This simple addition just adds a resolution multiplier to the size picker node to allow for the ability to easily multiply latent width and height without needing additonal math nodes to do so. I find that this is just convenient for these newer models.
![2025-04-20_20-27](https://github.com/user-attachments/assets/788ddba5-6670-44f1-a5ad-3709b586f59f)
